### PR TITLE
Update mapbox url schema

### DIFF
--- a/addon/services/map.js
+++ b/addon/services/map.js
@@ -11,10 +11,12 @@ export default Service.extend({
       zoom: 13
     });
     L.marker(point).addTo(map);
-    L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}', {
+    L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}', {
       attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
+      tileSize: 512,
       maxZoom: 18,
-      id: 'mapbox.streets',
+      zoomOffset: -1,
+      id: 'mapbox/streets-v11',
       accessToken: getOwner(this).resolveRegistration('config:environment')['ember-simple-leaflet-maps'].apiKey
     }).addTo(map);
     schedule('afterRender', () => map.invalidateSize());

--- a/addon/services/map.js
+++ b/addon/services/map.js
@@ -13,9 +13,7 @@ export default Service.extend({
     L.marker(point).addTo(map);
     L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}', {
       attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
-      tileSize: 512,
       maxZoom: 18,
-      zoomOffset: -1,
       id: 'mapbox/streets-v11',
       accessToken: getOwner(this).resolveRegistration('config:environment')['ember-simple-leaflet-maps'].apiKey
     }).addTo(map);


### PR DESCRIPTION
I was doing the super-rentals tutorial and the mapbox leaflets weren't working, turns out mapbox changed the url schema for leaflets ([documentation](https://docs.mapbox.com/help/troubleshooting/migrate-legacy-static-tiles-api/#will-the-apis-return-an-error-when-classic-styles-are-no-longer-supported))